### PR TITLE
Add composer.json and fix static warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "ethanclevenger91/picture-element-thumbnails",
+    "description": "Get a picture element instead of an image tag for responsive images on your WordPress site.",
+    "type": "wordpress-plugin",
+    "require": {
+        "composer/installers": "~1.0"
+    },
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Ethan Clevenger",
+            "email": "ethan.c.clevenger@gmail.com",
+            "homepage": "http://sternerstuffdesign.com/",
+            "role": "Developer"
+        }
+    ]
+}

--- a/picture-element-thumbnails.php
+++ b/picture-element-thumbnails.php
@@ -21,7 +21,7 @@ class WPPictureElement {
 	 * @param int $post_id
 	 * @return string
 	 */
-	function get_post_picture_element($default_image_size = 'thumbnail', $sizes=false, $post_id, $attr) {
+	public static function get_post_picture_element($default_image_size = 'thumbnail', $sizes=false, $post_id, $attr) {
 		if(has_post_thumbnail($post_id)) {
 			$thumbnail_id = get_post_thumbnail_id($post_id);
 			return self::get_picture_element($default_image_size, $sizes, $thumbnail_id, $attr);


### PR DESCRIPTION
You don't have a composer.json. This makes the plugin hard to work with. This commit adds a composer.json with some default information. Please feel free to change the info after merging this request. Just don't change the package name like you like to do.

Also fixes a function call that is used statically.
